### PR TITLE
fix: mark public functions as inline never

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,15 @@
 
 Relocate ELF dynamic symbols.
 
-Has to be included with
+Has to be used with
 
 ```toml
 [profile.dev.package.rcrt1]
 opt-level = 3
+debug-assertions = false
+overflow-checks = false
 ```
+
+in the `Cargo.toml` of the binary.
 
 License: Apache-2.0

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,8 +29,13 @@ use goblin::elf::reloc::R_X86_64_RELATIVE;
 ///
 /// This function is unsafe, because the caller has to ensure the dynamic section
 /// points to the correct memory.
-#[inline]
+#[inline(never)]
 pub unsafe extern "C" fn dyn_reloc(dynamic_section: *const u64, base: u64) {
+    inner_dyn_reloc(dynamic_section, base)
+}
+
+#[inline(always)]
+unsafe fn inner_dyn_reloc(dynamic_section: *const u64, base: u64) {
     let mut dt_rel: Option<u64> = None;
     let mut dt_relsz: usize = 0;
     let mut dt_rela: Option<u64> = None;
@@ -90,7 +95,7 @@ pub unsafe extern "C" fn dyn_reloc(dynamic_section: *const u64, base: u64) {
 /// # Safety
 ///
 /// This function is unsafe, because the caller has to ensure the stack pointer passed is setup correctly.
-#[inline]
+#[inline(never)]
 pub unsafe extern "C" fn rcrt(
     dynv: *const u64,
     sp: *const usize,
@@ -139,7 +144,7 @@ pub unsafe extern "C" fn rcrt(
             // calculate the offset, where the elf binary got loaded
             let base = dynv as u64 - (*ph).p_vaddr;
 
-            dyn_reloc(dynv, base);
+            inner_dyn_reloc(dynv, base);
 
             // Now call the `pre_main()` function and never return
             pre_main()


### PR DESCRIPTION
so that:
```
[profile.dev.package.rcrt1]
opt-level = 3
debug-assertions = false
overflow-checks = false
```
in the main crate takes effect.

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
