### PR TITLE
fix: remove `#![no_builtins]`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,6 @@
 #![no_std]
 #![deny(clippy::all)]
 #![deny(missing_docs)]
-#![no_builtins]
 
 const R_TYPE_MASK: u64 = 0x7fffffff;
 


### PR DESCRIPTION
```
[…]
rcrt1.5cde00ae-cgu.0:(.text._ZN5rcrt14rcrt17h1448af6554dc2f53E+0x80): undefined reference to `core::panicking::panic'
[…]
```

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
